### PR TITLE
Hengle/form attributes

### DIFF
--- a/spec/test_pg.cr
+++ b/spec/test_pg.cr
@@ -54,16 +54,16 @@ class Post < Crecto::Model
   end
 end
 
-# add your models
-admin_resource(User, Repo)
-admin_resource(Post, Repo)
-
 CrectoAdmin.config do |c|
   c.auth_repo = Repo
   c.auth_model = User
   c.auth_model_identifier = :email
   c.auth_model_password = :encrypted_password
 end
+
+# add your models
+admin_resource(User, Repo)
+admin_resource(Post, Repo)
 
 Kemal::Session.config do |config|
   config.secret = "my super secret"

--- a/spec/test_pg.cr
+++ b/spec/test_pg.cr
@@ -21,12 +21,36 @@ class User < Crecto::Model
     field :first_posted, Time
     field :last_posted, Time
   end
+
+  def self.collection_attributes
+    [:email, :status, :count, :score, :is_active, :first_posted, :last_posted, :updated_at, :created_at]
+  end
+
+  def self.form_attributes
+    [{:email, "string"},
+     {:encrypted_password, "password"},
+     {:status, "enum", ["Good", "Error"]},
+     {:count, "int"},
+     {:score, "float"},
+     {:is_active, "bool"},
+     {:first_posted, "time"},
+     {:last_posted, "time"}]
+  end
 end
 
 class Post < Crecto::Model
   schema "posts" do
     field :user_id, Int64
     field :content, String
+  end
+
+  def self.search_attributes
+    [:content]
+  end
+
+  def self.form_attributes
+    [{:user_id, "int"},
+     {:content, "text"}]
   end
 end
 

--- a/spec/test_pg.cr
+++ b/spec/test_pg.cr
@@ -1,7 +1,4 @@
 require "pg"
-require "crecto"
-require "kemal"
-require "crypto/bcrypt/password"
 require "../src/crecto-admin"
 
 module Repo
@@ -9,7 +6,7 @@ module Repo
 
   config do |conf|
     conf.adapter = Crecto::Adapters::Postgres
-    conf.uri = ENV["PG_URL"]
+    conf.uri = "postgres://postgres:postgres@localhost:5432/crecto_admin_test"
   end
 end
 

--- a/src/CrectoAdmin/resource.cr
+++ b/src/CrectoAdmin/resource.cr
@@ -7,7 +7,7 @@ def self.admin_resource(model : Crecto::Model.class, repo, **opts)
     form_attributes.concat(model.form_attributes)
   else
     model.fields.each do |f|
-      if CrectoAdmin.config.auth_model_password == f[:name]
+      if CrectoAdmin.config.auth_repo == repo && CrectoAdmin.config.auth_model_password == f[:name]
         form_attributes << {f[:name], "password"}
       else
         attr_type = f[:type].to_s

--- a/src/CrectoAdmin/views/_form_fields.ecr
+++ b/src/CrectoAdmin/views/_form_fields.ecr
@@ -1,36 +1,73 @@
 <% resource[:form_attributes].each do |attr| %>
-  <% next if attr == item.class.primary_key_field_symbol %>
-  <% next if attr.to_s == item.class.updated_at_field %>
-  <% next if attr.to_s == item.class.created_at_field %>
+  <% attr_name = attr[0] %>
+  <% attr_type = attr[1] %>
+  <% next if attr_name == item.class.primary_key_field_symbol %>
+  <% next if attr_name.to_s == item.class.updated_at_field %>
+  <% next if attr_name.to_s == item.class.created_at_field %>
   <% query_hash = item.to_query_hash %>
-  <% field_type = item.class.fields.select{|f| f[:name] == attr }[0][:type] %>
   <div class="field">
-    <% if field_type == "Bool" %>
+    <% if attr_type == "bool" %>
       <div class="control">
         <label class="checkbox">
-          <input placeholder="<%= attr %>" name="<%= attr %>" id="<%= attr %>" type="checkbox" <% if query_hash[attr] == true %>checked="checked"<% end %>>
-          <%= attr %>
+          <input placeholder="<%= attr_name %>" name="<%= attr_name %>" id="<%= attr_name %>" type="checkbox" <% if query_hash[attr_name] == true %>checked="checked"<% end %>>
+          <%= attr_name %>
         </label>
       </div>
-    <% elsif field_type == "Time" %>
-      <label class="label"><%= attr %></label>
+    <% elsif attr_type == "int" %>
+      <label class="label"><%= attr_name %></label>
       <div class="control">
-        <input id="<%= attr %>" type="text" class="input datetime-picker" name="<%= attr %>" value="<%= query_hash[attr] %>">
+        <input class="input" placeholder="<%= attr_name %>" name="<%= attr_name %>" id="<%= attr_name %>" type="number" value="<%= query_hash[attr_name] %>">
       </div>
-    <% elsif field_type == "String" %>
-      <label class="label"><%= attr %></label>
+    <% elsif attr_type == "float" %>
+      <label class="label"><%= attr_name %></label>
       <div class="control">
-        <input class="input" placeholder="<%= attr %>" name="<%= attr %>" id="<%= attr %>" type="text" value="<%= query_hash[attr] %>">
+        <input class="input" placeholder="<%= attr_name %>" name="<%= attr_name %>" id="<%= attr_name %>" type="number" step="any" value="<%= query_hash[attr_name] %>">
       </div>
-    <% elsif field_type == "Json" %>
-      <label class="label"><%= attr %></label>
+    <% elsif attr_type == "string" %>
+      <label class="label"><%= attr_name %></label>
       <div class="control">
-        <input class="input" placeholder="<%= attr %>" name="<%= attr %>" id="<%= attr %>" type="text" value='<%= query_hash[attr].to_json %>'>
+        <input class="input" placeholder="<%= attr_name %>" name="<%= attr_name %>" id="<%= attr_name %>" type="text" value="<%= query_hash[attr_name] %>">
+      </div>
+    <% elsif attr_type == "text" %>
+      <label class="label"><%= attr_name %></label>
+      <div class="control">
+        <textarea class="textarea" placeholder="<%= attr_name %>" id="<%= attr_name %>" name="<%= attr_name %>"><%= query_hash[attr_name] %></textarea>
+      </div>
+    <% elsif attr_type == "enum" %>
+      <label class="label"><%= attr_name %></label>
+      <div class="control">
+        <div class="select">
+          <select id="<%= attr_name %>" name="<%= attr_name %>">
+            <% if attr.size == 3 %>
+              <% options = attr.last.as(Array(String)) %>
+              <% attr_value = query_hash[attr_name].to_s %>
+              <% options = (options.includes?(attr_value) || attr_value.empty?) ? options : (options + [attr_value])   %>
+              <% options.each do |opt| %>
+                <% if opt == query_hash[attr_name] %>
+                  <option selected><%= opt %></option>
+                <% else %>
+                  <option><%= opt %></option>
+                <% end %>
+              <% end %>
+            <% end %>
+          </select>
+        </div>
+      </div>
+    <% elsif attr_type == "password" %>
+      <label class="label"><%= attr_name %></label>
+      <div class="control">
+        <input class="input" placeholder="<%= attr_name %>" name="<%= attr_name %>" id="<%= attr_name %>" type="password">
+      </div>
+      <p class="help is-info">Input raw password (NOT encrypted password) to set. Leave it empty if you do not want to change.</p>
+    <% elsif attr_type == "time" %>
+      <label class="label"><%= attr_name %></label>
+      <div class="control">
+        <input id="<%= attr_name %>" type="text" class="input datetime-picker" name="<%= attr_name %>" value="<%= query_hash[attr_name] %>">
       </div>
     <% else %>
-      <label class="label"><%= attr %></label>
+      <label class="label"><%= attr_name %></label>
       <div class="control">
-        <input class="input" placeholder="<%= attr %>" name="<%= attr %>" id="<%= attr %>" type="text" value="<%= query_hash[attr] %>">
+        <textarea class="textarea" placeholder="<%= attr_name %>" rows="2" id="<%= attr_name %>" name="<%= attr_name %>"><%= query_hash[attr_name] %></textarea>
       </div>
     <% end %>
   </div>

--- a/src/CrectoAdmin/views/admin_layout.ecr
+++ b/src/CrectoAdmin/views/admin_layout.ecr
@@ -48,11 +48,11 @@
     </nav>
 
     <div id="main" class="container is-fluid">
-      <div class="columns">
+      <div class="columns" style="padding-left:5px;padding-right:5px">
         <% if CrectoAdmin.admin_signed_in?(ctx) %>
           <div class="column is-narrow">
             <aside class="menu left-siebar-nav">
-              <ul class="menu-list">
+              <ul class="menu-list has-text-weight-bold">
                 <% if CrectoAdmin.current_table(ctx) == "dashboard" %>
                   <li><a class="is-active" href="/admin/dashboard">Dashboard</a></li>
                 <% else %>

--- a/src/CrectoAdmin/views/dashboard.ecr
+++ b/src/CrectoAdmin/views/dashboard.ecr
@@ -15,7 +15,7 @@
     <tbody>
       <% CrectoAdmin.resources.each_with_index do |resource, i| %>
         <tr class="item-row" data-href="/admin/<%= resource[:model].table_name %>">
-          <td><%= resource[:model].table_name.split('_').map(&.capitalize).join(' ') %></td>
+          <th><%= resource[:model].table_name.split('_').map(&.capitalize).join(' ') %></th>
           <td><%= resource[:collection_attributes].map(&.to_s).join(", ") %></td>
           <td><%= counts[i] %></td>
         </tr>

--- a/src/CrectoAdmin/views/sign_in.ecr
+++ b/src/CrectoAdmin/views/sign_in.ecr
@@ -4,7 +4,7 @@
 
     <div class="field">
       <% user_label = CrectoAdmin.config.auth_model_identifier.nil? ? "user" : CrectoAdmin.config.auth_model_identifier %>
-      <label class="label" style="text-transform:capitalize;">
+      <label class="label is-capitalized">
         <%= user_label %>
       </label>
       <div class="control has-icons-left">

--- a/src/crecto-admin.cr
+++ b/src/crecto-admin.cr
@@ -15,7 +15,7 @@ module CrectoAdmin
     repo: Repo.class,
     collection_attributes: Array(Symbol),
     show_page_attributes: Array(Symbol),
-    form_attributes: Array(Symbol))).new
+    form_attributes: Array(Tuple(Symbol, String) | Tuple(Symbol, String, Array(String))))).new
 
   def self.add_resource(resource)
     @@resources.push(resource)

--- a/src/crecto-admin.cr
+++ b/src/crecto-admin.cr
@@ -1,7 +1,9 @@
+require "crecto"
 require "kemal"
 require "kemal-csrf"
 require "kemal-session"
 require "kemal-flash"
+require "crypto/bcrypt/password"
 require "./CrectoAdmin/*"
 
 module CrectoAdmin


### PR DESCRIPTION
Branch out from the previous pull request:

Make `form_attributes: Array(Tuple(Symbol, String) | Tuple(Symbol, String, Array(String)))` so that each form_attribute is something like `{name(Symbol), type(String), options: Array(String)(only for enum type)}`. For example, `{:status, "enum", ["Good", "Error"]}` or `{:encrypted_password, "password"}`.
The `type` is a string:
- `bool`: checkbox
- `int`: input number
- `float`: input number
- `string`: input text
- `text`: textarea
- `enum`: select from the `options: Array(String)`
- `password`: input password
- `time`: datetime picker

For `password` field, allow users to input raw password, and compute the encrypted password in the backend and save to db.

Search attribute bug fix and misc style improvements.