### PR TITLE
Hengle/basic auth

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -27,6 +27,9 @@ dependencies:
   kemal-flash:
     github: neovintage/kemal-flash
 
+  kemal-basic-auth:
+    github: kemalcr/kemal-basic-auth
+
 development_dependencies:
   mysql:
     github: crystal-lang/crystal-mysql

--- a/spec/test_pg.cr
+++ b/spec/test_pg.cr
@@ -55,11 +55,19 @@ class Post < Crecto::Model
 end
 
 CrectoAdmin.config do |c|
+  c.auth = CrectoAdmin::BasicAuth
+  c.basic_auth_credentials = {"a" => "b", "c" => "d"}
   c.auth_repo = Repo
   c.auth_model = User
   c.auth_model_identifier = :email
   c.auth_model_password = :encrypted_password
+  c.custom_auth_method = ->(user_identifier : String, password : String) {
+    return "custom autherized user"
+  }
 end
+
+# init admin server
+init_admin()
 
 # add your models
 admin_resource(User, Repo)

--- a/src/CrectoAdmin/config.cr
+++ b/src/CrectoAdmin/config.cr
@@ -8,22 +8,14 @@ module CrectoAdmin
     property auth_model : (Crecto::Model.class)?
     property auth_model_identifier : Symbol?
     property auth_model_password : Symbol?
-    property auth_method : Proc(String, String, String)?
+    property basic_auth_credentials : Hash(String, String)?
+    property custom_auth_method : Proc(String, String, String)?
 
     def initialize
       @auth_enabled = true
       @auth = CrectoAdmin::DatabaseAuth
       @auth_model_identifier = :email
       @auth_model_password = :encrypted_password
-      @auth_method = ->(user_identifier : String, password : String) {
-        query = Crecto::Repo::Query.where(@auth_model_identifier.not_nil!, user_identifier).limit(1)
-        users = @auth_repo.not_nil!.all(@auth_model.not_nil!, query)
-        return "" unless users.size == 1
-        user = users.first
-        encrypted_password = user.to_query_hash[@auth_model_password.not_nil!].to_s
-        return "" unless Crypto::Bcrypt::Password.new(encrypted_password) == password
-        return user_identifier
-      }
     end
   end
 

--- a/src/CrectoAdmin/views/admin_layout.ecr
+++ b/src/CrectoAdmin/views/admin_layout.ecr
@@ -25,22 +25,24 @@
         </div>
         <div class="navbar-menu is-active">
           <div class="navbar-end">
-            <% if CrectoAdmin.admin_signed_in?(ctx) && CrectoAdmin.config.auth_enabled %>
+            <% if CrectoAdmin.config.auth_enabled && CrectoAdmin.admin_signed_in?(ctx) %>
               <a class="navbar-item">
                 Signed in as <%= CrectoAdmin.current_user(ctx) %>
               </a>
-              <div class="navbar-item">
-                <div class="field is-grouped">
-                  <p class="control">
-                    <a class="button" href="/admin/sign_out">
-                      <span class="icon">
-                        <i class="fas fa-sign-out-alt"></i>
-                      </span>
-                      <span>Sign Out</span>
-                    </a>
-                  </p>
+              <% if CrectoAdmin.config.auth != CrectoAdmin::BasicAuth %>
+                <div class="navbar-item">
+                  <div class="field is-grouped">
+                    <p class="control">
+                      <a class="button" href="/admin/sign_out">
+                        <span class="icon">
+                          <i class="fas fa-sign-out-alt"></i>
+                        </span>
+                        <span>Sign Out</span>
+                      </a>
+                    </p>
+                  </div>
                 </div>
-              </div>
+              <% end %>
             <% end %>
           </div>
         </div>

--- a/src/crecto-admin.cr
+++ b/src/crecto-admin.cr
@@ -3,11 +3,15 @@ require "kemal"
 require "kemal-csrf"
 require "kemal-session"
 require "kemal-flash"
+require "kemal-basic-auth"
 require "crypto/bcrypt/password"
 require "./CrectoAdmin/*"
 
 module CrectoAdmin
-  DatabaseAuth       = "DatabaseAuth"
+  DatabaseAuth = "DatabaseAuth"
+  BasicAuth    = "BasicAuth"
+  CustomAuth   = "CustomAuth"
+
   SESSION_KEY        = "8kezPq9GRAMm"
   AUTH_ALLOWED_PATHS = ["/admin", "/admin/sign_in"]
 
@@ -42,8 +46,18 @@ module CrectoAdmin
       ctx.params.query["search"]?
   end
 
-  def self.current_user(ctx)
-    ctx.session.string(SESSION_KEY)
+  def self.current_user(ctx) : String
+    return "" unless CrectoAdmin.config.auth_enabled
+    if CrectoAdmin.config.auth == CrectoAdmin::BasicAuth
+      username = ctx.kemal_authorized_username?
+      return "" if username.nil?
+      return username.to_s
+    end
+    if CrectoAdmin.config.auth == CrectoAdmin::DatabaseAuth || CrectoAdmin.config.auth == CrectoAdmin::CustomAuth
+      return "" unless ctx.session.string?(SESSION_KEY) && !ctx.session.string(SESSION_KEY).empty?
+      return ctx.session.string(SESSION_KEY)
+    end
+    return ""
   end
 
   def self.current_table(ctx)
@@ -54,6 +68,7 @@ module CrectoAdmin
 
   def self.admin_signed_in?(ctx)
     return true unless CrectoAdmin.config.auth_enabled
+    return true if CrectoAdmin.config.auth == CrectoAdmin::BasicAuth
     ctx.session.string?(SESSION_KEY) && !ctx.session.string(SESSION_KEY).empty?
   end
 
@@ -68,42 +83,73 @@ module CrectoAdmin
   end
 end
 
-add_handler CSRF.new
+def self.init_admin
+  add_handler CSRF.new
 
-before_all "/admin/*" do |ctx|
-  next if CrectoAdmin::AUTH_ALLOWED_PATHS.includes?(ctx.request.path)
-  ctx.redirect "/admin/sign_in" unless CrectoAdmin.admin_signed_in?(ctx)
-end
-
-get "/admin" do |ctx|
-  ctx.redirect "/admin/dashboard"
-end
-
-get "/admin/dashboard" do |ctx|
-  counts = [] of Int64
-  CrectoAdmin.resources.each do |resource|
-    counts << resource[:repo].aggregate(resource[:model], :count, resource[:model].primary_key_field_symbol).as(Int64)
+  if CrectoAdmin.config.auth_enabled && CrectoAdmin.config.auth == CrectoAdmin::BasicAuth
+    basic_auth CrectoAdmin.config.basic_auth_credentials.not_nil!
   end
-  ecr "dashboard"
-end
 
-get "/admin/sign_in" do |ctx|
-  ecr "sign_in"
-end
+  before_all "/admin/*" do |ctx|
+    next if CrectoAdmin::AUTH_ALLOWED_PATHS.includes?(ctx.request.path)
+    ctx.redirect "/admin/sign_in" unless CrectoAdmin.admin_signed_in?(ctx)
+  end
 
-post "/admin/sign_in" do |ctx|
-  user_identifier = ctx.params.body["user"].to_s
-  password = ctx.params.body["password"].to_s
-  authorized = CrectoAdmin.config.auth_method.not_nil!.call(user_identifier, password)
-  if authorized.empty?
-    ctx.redirect "/admin/sign_in"
-  else
-    ctx.session.string(CrectoAdmin::SESSION_KEY, authorized)
+  get "/admin" do |ctx|
     ctx.redirect "/admin/dashboard"
   end
-end
 
-get "/admin/sign_out" do |ctx|
-  ctx.session.string(CrectoAdmin::SESSION_KEY, "")
-  ctx.redirect "/admin/sign_in"
+  get "/admin/dashboard" do |ctx|
+    counts = [] of Int64
+    CrectoAdmin.resources.each do |resource|
+      counts << resource[:repo].aggregate(resource[:model], :count, resource[:model].primary_key_field_symbol).as(Int64)
+    end
+    ecr "dashboard"
+  end
+
+  get "/admin/sign_in" do |ctx|
+    unless CrectoAdmin.config.auth_enabled
+      next ctx.redirect "/admin/dashboard"
+    end
+    if CrectoAdmin.config.auth == CrectoAdmin::BasicAuth
+      next ctx.redirect "/admin/dashboard"
+    end
+    ecr "sign_in"
+  end
+
+  post "/admin/sign_in" do |ctx|
+    unless CrectoAdmin.config.auth_enabled
+      next ctx.redirect "/admin/dashboard"
+    end
+    if CrectoAdmin.config.auth == CrectoAdmin::BasicAuth
+      next ctx.redirect "/admin/dashboard"
+    end
+    user_identifier = ctx.params.body["user"].to_s
+    password = ctx.params.body["password"].to_s
+    authorized = ""
+    if CrectoAdmin.config.auth == CrectoAdmin::CustomAuth
+      authorized = CrectoAdmin.config.custom_auth_method.not_nil!.call(user_identifier, password)
+    elsif CrectoAdmin.config.auth == CrectoAdmin::DatabaseAuth
+      query = Crecto::Repo::Query.where(CrectoAdmin.config.auth_model_identifier.not_nil!, user_identifier).limit(1)
+      users = CrectoAdmin.config.auth_repo.not_nil!.all(CrectoAdmin.config.auth_model.not_nil!, query)
+      if users.size == 1
+        user = users.first
+        encrypted_password = user.to_query_hash[CrectoAdmin.config.auth_model_password.not_nil!].to_s
+        if Crypto::Bcrypt::Password.new(encrypted_password) == password
+          authorized = user_identifier
+        end
+      end
+    end
+    if authorized.empty?
+      ctx.redirect "/admin/sign_in"
+    else
+      ctx.session.string(CrectoAdmin::SESSION_KEY, authorized)
+      ctx.redirect "/admin/dashboard"
+    end
+  end
+
+  get "/admin/sign_out" do |ctx|
+    ctx.session.string(CrectoAdmin::SESSION_KEY, "")
+    ctx.redirect "/admin/sign_in"
+  end
 end


### PR DESCRIPTION
There are three auth types now:
- basic auth: `auth = CrectoAdmin::BasicAuth`, `basic_auth_credentials`
- database auth: `auth = CrectoAdmin::DatabaseAuth`, `auth_repo`, `auth_model`, `auth_model_identifier`, `auth_model_password`. It will use default method to check user identifier and password.
- custom auth: `auth = CrectoAdmin::CustomAuth`, `custom_auth_method `. It will ignore other settings, and just call user defined`custom_auth_method(user : String, password : String) : String` directly to authenticate a user. Return the authenticated user identifier if succeed or empty string if fail.

Need to put the admin server handlers in the the `init_admin` method, and call it after setting the config. Otherwise, it will set the handler when importing the `CrectoAdmin` before setting the `CrectoAdmin.config`