### PR TITLE
Hengle/permission

### DIFF
--- a/spec/test_pg.cr
+++ b/spec/test_pg.cr
@@ -55,7 +55,7 @@ class Post < Crecto::Model
 end
 
 CrectoAdmin.config do |c|
-  c.auth = CrectoAdmin::BasicAuth
+  c.auth = CrectoAdmin::DatabaseAuth
   c.basic_auth_credentials = {"a" => "b", "c" => "d"}
   c.auth_repo = Repo
   c.auth_model = User

--- a/spec/test_pg.cr
+++ b/spec/test_pg.cr
@@ -70,6 +70,7 @@ class Post < Crecto::Model
 end
 
 CrectoAdmin.config do |c|
+  c.auth_enabled = true
   c.auth = CrectoAdmin::DatabaseAuth
   c.basic_auth_credentials = {"a" => "b", "c" => "d"}
   c.auth_repo = Repo

--- a/spec/test_pg.cr
+++ b/spec/test_pg.cr
@@ -27,14 +27,22 @@ class User < Crecto::Model
   end
 
   def self.form_attributes
-    [{:email, "string"},
+    [:email,
      {:encrypted_password, "password"},
      {:status, "enum", ["Good", "Error"]},
      {:count, "int"},
-     {:score, "float"},
+     {:score, "fixed", "100.5"},
      {:is_active, "bool"},
      {:first_posted, "time"},
      {:last_posted, "time"}]
+  end
+
+  def self.can_access(user)
+    return true unless user.is_a? User
+    user = user.as(User)
+    return true if user.email.to_s == "jianghengle@gmail.com"
+    query = Crecto::Repo::Query.where(id: user.id)
+    return {query, [:email, :encrypted_password, :status]}
   end
 end
 
@@ -45,7 +53,7 @@ class Post < Crecto::Model
   end
 
   def self.search_attributes
-    [:content]
+    [:user_id, :content]
   end
 
   def self.form_attributes

--- a/spec/test_pg.cr
+++ b/spec/test_pg.cr
@@ -38,7 +38,7 @@ class User < Crecto::Model
   end
 
   def self.can_access(user)
-    return true unless user.is_a? User
+    return false unless user.is_a? User
     user = user.as(User)
     return true if user.email.to_s == "jianghengle@gmail.com"
     query = Crecto::Repo::Query.where(id: user.id)
@@ -59,6 +59,13 @@ class Post < Crecto::Model
   def self.form_attributes
     [{:user_id, "int"},
      {:content, "text"}]
+  end
+
+  def self.can_access(user)
+    return false unless user.is_a? User
+    user = user.as(User)
+    return true if user.email.to_s == "jianghengle@gmail.com"
+    Crecto::Repo::Query.where(user_id: user.id)
   end
 end
 

--- a/src/CrectoAdmin/resource.cr
+++ b/src/CrectoAdmin/resource.cr
@@ -1,6 +1,9 @@
 def self.admin_resource(model : Crecto::Model.class, repo, **opts)
-  collection_attributes = model.responds_to?(:collection_attributes) ? model.collection_attributes : model.fields.map { |f| f[:name] }
-  show_page_attributes = model.responds_to?(:show_page_attributes) ? model.show_page_attributes : model.fields.map { |f| f[:name] }
+  model_attributes = model.fields.map { |f| f[:name] }
+  model_attributes.delete(model.primary_key_field_symbol)
+  model_attributes.unshift(model.primary_key_field_symbol)
+
+  collection_attributes = model.responds_to?(:collection_attributes) ? model.collection_attributes : model_attributes
 
   form_attributes = [] of Tuple(Symbol, String) | Tuple(Symbol, String, Array(String))
   if model.responds_to?(:form_attributes)
@@ -26,13 +29,13 @@ def self.admin_resource(model : Crecto::Model.class, repo, **opts)
     end
   end
 
-  search_attributes = model.responds_to?(:search_attributes) ? model.search_attributes : model.fields.map { |f| f[:name] }
+  search_attributes = model.responds_to?(:search_attributes) ? model.search_attributes : model_attributes
   per_page = 20
   resource = {
     model:                 model,
     repo:                  repo,
+    model_attributes:      model_attributes,
     collection_attributes: collection_attributes,
-    show_page_attributes:  show_page_attributes,
     form_attributes:       form_attributes,
   }
 

--- a/src/CrectoAdmin/resource.cr
+++ b/src/CrectoAdmin/resource.cr
@@ -43,10 +43,10 @@ def self.admin_resource(model : Crecto::Model.class, repo, **opts)
 
   # Index
   get "/admin/#{model.table_name}" do |ctx|
-    accessibility = CrectoAdmin.model_accessibility(ctx, resource)
-    next if accessibility[0].nil? || accessibility[1].empty?
-    model_query = accessibility[0].as(Crecto::Repo::Query)
-    collection_attributes = resource[:collection_attributes].select { |a| accessibility[1].includes? a }
+    access = CrectoAdmin.model_access(ctx, resource)
+    next if access[0].nil? || access[1].empty?
+    model_query = access[0].as(Crecto::Repo::Query)
+    collection_attributes = resource[:collection_attributes].select { |a| access[1].includes? a }
     offset = ctx.params.query["offset"]? ? ctx.params.query["offset"].to_i : 0
     query = model_query.limit(per_page).offset(offset)
     data = repo.all(model, query)
@@ -56,11 +56,11 @@ def self.admin_resource(model : Crecto::Model.class, repo, **opts)
 
   # Search
   get "/admin/#{model.table_name}/search" do |ctx|
-    accessibility = CrectoAdmin.model_accessibility(ctx, resource)
-    next if accessibility[0].nil? || accessibility[1].empty?
-    model_query = accessibility[0].as(Crecto::Repo::Query)
-    collection_attributes = resource[:collection_attributes].select { |a| accessibility[1].includes? a }
-    search_attributes = search_attributes.select { |a| accessibility[1].includes? a }
+    access = CrectoAdmin.model_access(ctx, resource)
+    next if access[0].nil? || access[1].empty?
+    model_query = access[0].as(Crecto::Repo::Query)
+    collection_attributes = resource[:collection_attributes].select { |a| access[1].includes? a }
+    search_attributes = search_attributes.select { |a| access[1].includes? a }
     search_attributes.delete(model.primary_key_field_symbol)
     search_attributes.unshift(model.primary_key_field_symbol)
     offset = ctx.params.query["offset"]? ? ctx.params.query["offset"].to_i : 0
@@ -83,14 +83,14 @@ def self.admin_resource(model : Crecto::Model.class, repo, **opts)
 
   # View
   get "/admin/#{model.table_name}/:id" do |ctx|
-    accessibility = CrectoAdmin.model_accessibility(ctx, resource)
-    next if accessibility[0].nil? || accessibility[1].empty?
-    model_query = accessibility[0].as(Crecto::Repo::Query)
+    access = CrectoAdmin.model_access(ctx, resource)
+    next if access[0].nil? || access[1].empty?
+    model_query = access[0].as(Crecto::Repo::Query)
     query = model_query.where(resource[:model].primary_key_field_symbol, ctx.params.url["id"])
     data = repo.all(model, query).not_nil!
     next if data.empty?
     item = data.first
-    model_attributes = accessibility[1]
+    model_attributes = access[1]
     ecr("show")
   end
 

--- a/src/CrectoAdmin/resource.cr
+++ b/src/CrectoAdmin/resource.cr
@@ -5,7 +5,7 @@ def self.admin_resource(model : Crecto::Model.class, repo, **opts)
 
   collection_attributes = model.responds_to?(:collection_attributes) ? model.collection_attributes : model_attributes
 
-  form_attributes = [] of Tuple(Symbol, String) | Tuple(Symbol, String, Array(String))
+  form_attributes = [] of Symbol | Tuple(Symbol, String) | Tuple(Symbol, String, Array(String) | String)
   if model.responds_to?(:form_attributes)
     form_attributes.concat(model.form_attributes)
   else
@@ -23,7 +23,7 @@ def self.admin_resource(model : Crecto::Model.class, repo, **opts)
         elsif attr_type == "Time"
           form_attributes << {f[:name], "time"}
         else
-          form_attributes << {f[:name], "default"}
+          form_attributes << f[:name]
         end
       end
     end
@@ -43,24 +43,35 @@ def self.admin_resource(model : Crecto::Model.class, repo, **opts)
 
   # Index
   get "/admin/#{model.table_name}" do |ctx|
+    accessibility = CrectoAdmin.model_accessibility(ctx, resource)
+    next if accessibility[0].nil? || accessibility[1].empty?
+    model_query = accessibility[0].as(Crecto::Repo::Query)
+    collection_attributes = resource[:collection_attributes].select { |a| accessibility[1].includes? a }
     offset = ctx.params.query["offset"]? ? ctx.params.query["offset"].to_i : 0
-    query = Crecto::Repo::Query.limit(per_page).offset(offset)
+    query = model_query.limit(per_page).offset(offset)
     data = repo.all(model, query)
-    count = repo.aggregate(model, :count, resource[:model].primary_key_field_symbol).as(Int64)
+    count = repo.aggregate(model, :count, resource[:model].primary_key_field_symbol, model_query).as(Int64)
     ecr("index")
   end
 
   # Search
   get "/admin/#{model.table_name}/search" do |ctx|
+    accessibility = CrectoAdmin.model_accessibility(ctx, resource)
+    next if accessibility[0].nil? || accessibility[1].empty?
+    model_query = accessibility[0].as(Crecto::Repo::Query)
+    collection_attributes = resource[:collection_attributes].select { |a| accessibility[1].includes? a }
+    search_attributes = search_attributes.select { |a| accessibility[1].includes? a }
+    search_attributes.delete(model.primary_key_field_symbol)
+    search_attributes.unshift(model.primary_key_field_symbol)
     offset = ctx.params.query["offset"]? ? ctx.params.query["offset"].to_i : 0
     search_string = search_attributes.map { |sa| "#{CrectoAdmin.field_cast(sa, repo)} LIKE ?" }.join(" OR ")
     search_params = (1..search_attributes.size).map { |x| "%#{CrectoAdmin.search_param(ctx)}%" }
-    query = Crecto::Repo::Query
+    query = model_query
       .limit(per_page)
       .where(search_string, search_params)
       .offset(offset)
     data = repo.all(model, query)
-    count = repo.aggregate(model, :count, resource[:model].primary_key_field_symbol, Crecto::Repo::Query.where(search_string, search_params)).as(Int64)
+    count = repo.aggregate(model, :count, resource[:model].primary_key_field_symbol, model_query).as(Int64)
     ecr("index")
   end
 
@@ -72,7 +83,14 @@ def self.admin_resource(model : Crecto::Model.class, repo, **opts)
 
   # View
   get "/admin/#{model.table_name}/:id" do |ctx|
-    item = repo.get!(model, ctx.params.url["id"])
+    accessibility = CrectoAdmin.model_accessibility(ctx, resource)
+    next if accessibility[0].nil? || accessibility[1].empty?
+    model_query = accessibility[0].as(Crecto::Repo::Query)
+    query = model_query.where(resource[:model].primary_key_field_symbol, ctx.params.url["id"])
+    data = repo.all(model, query).not_nil!
+    next if data.empty?
+    item = data.first
+    model_attributes = accessibility[1]
     ecr("show")
   end
 
@@ -81,6 +99,8 @@ def self.admin_resource(model : Crecto::Model.class, repo, **opts)
     item = repo.get!(model, ctx.params.url["pid_id"])
     query_hash = ctx.params.body.to_h
     resource[:form_attributes].each do |attr|
+      next if attr.is_a? Symbol
+      attr = attr.as(Tuple(Symbol, String) | Tuple(Symbol, String, Array(String) | String))
       if attr[1] == "bool"
         query_hash[attr[0].to_s] = query_hash[attr[0].to_s]? == "on" ? "true" : "false"
       elsif attr[1] == "password"
@@ -117,6 +137,8 @@ def self.admin_resource(model : Crecto::Model.class, repo, **opts)
     item = model.new
     query_hash = ctx.params.body.to_h
     resource[:form_attributes].each do |attr|
+      next if attr.is_a? Symbol
+      attr = attr.as(Tuple(Symbol, String) | Tuple(Symbol, String, Array(String) | String))
       if attr[1] == "bool"
         query_hash[attr[0].to_s] = query_hash[attr[0].to_s]? == "on" ? "true" : "false"
       elsif attr[1] == "password"

--- a/src/CrectoAdmin/views/_form_fields.ecr
+++ b/src/CrectoAdmin/views/_form_fields.ecr
@@ -1,74 +1,99 @@
 <% resource[:form_attributes].each do |attr| %>
-  <% attr_name = attr[0] %>
-  <% attr_type = attr[1] %>
-  <% next if attr_name == item.class.primary_key_field_symbol %>
-  <% next if attr_name.to_s == item.class.updated_at_field %>
-  <% next if attr_name.to_s == item.class.created_at_field %>
   <% query_hash = item.to_query_hash %>
-  <div class="field">
-    <% if attr_type == "bool" %>
-      <div class="control">
-        <label class="checkbox">
-          <input placeholder="<%= attr_name %>" name="<%= attr_name %>" id="<%= attr_name %>" type="checkbox" <% if query_hash[attr_name] == true %>checked="checked"<% end %>>
-          <%= attr_name %>
-        </label>
-      </div>
-    <% elsif attr_type == "int" %>
-      <label class="label"><%= attr_name %></label>
-      <div class="control">
-        <input class="input" placeholder="<%= attr_name %>" name="<%= attr_name %>" id="<%= attr_name %>" type="number" value="<%= query_hash[attr_name] %>">
-      </div>
-    <% elsif attr_type == "float" %>
-      <label class="label"><%= attr_name %></label>
-      <div class="control">
-        <input class="input" placeholder="<%= attr_name %>" name="<%= attr_name %>" id="<%= attr_name %>" type="number" step="any" value="<%= query_hash[attr_name] %>">
-      </div>
-    <% elsif attr_type == "string" %>
-      <label class="label"><%= attr_name %></label>
-      <div class="control">
-        <input class="input" placeholder="<%= attr_name %>" name="<%= attr_name %>" id="<%= attr_name %>" type="text" value="<%= query_hash[attr_name] %>">
-      </div>
-    <% elsif attr_type == "text" %>
-      <label class="label"><%= attr_name %></label>
-      <div class="control">
-        <textarea class="textarea" placeholder="<%= attr_name %>" id="<%= attr_name %>" name="<%= attr_name %>"><%= query_hash[attr_name] %></textarea>
-      </div>
-    <% elsif attr_type == "enum" %>
-      <label class="label"><%= attr_name %></label>
-      <div class="control">
-        <div class="select">
-          <select id="<%= attr_name %>" name="<%= attr_name %>">
-            <% if attr.size == 3 %>
-              <% options = attr.last.as(Array(String)) %>
-              <% attr_value = query_hash[attr_name].to_s %>
-              <% options = (options.includes?(attr_value) || attr_value.empty?) ? options : (options + [attr_value])   %>
-              <% options.each do |opt| %>
-                <% if opt == query_hash[attr_name] %>
-                  <option selected><%= opt %></option>
-                <% else %>
-                  <option><%= opt %></option>
-                <% end %>
-              <% end %>
-            <% end %>
-          </select>
-        </div>
-      </div>
-    <% elsif attr_type == "password" %>
-      <label class="label"><%= attr_name %></label>
-      <div class="control">
-        <input class="input" placeholder="<%= attr_name %>" name="<%= attr_name %>" id="<%= attr_name %>" type="password">
-      </div>
-      <p class="help is-info">Input raw password (NOT encrypted password) to set. Leave it empty if you do not want to change.</p>
-    <% elsif attr_type == "time" %>
-      <label class="label"><%= attr_name %></label>
-      <div class="control">
-        <input id="<%= attr_name %>" type="text" class="input datetime-picker" name="<%= attr_name %>" value="<%= query_hash[attr_name] %>">
-      </div>
-    <% else %>
+  <% if attr.is_a? Symbol %>
+    <% attr_name = attr.as(Symbol) %>
+    <% next if attr_name == item.class.primary_key_field_symbol %>
+    <% next if attr_name.to_s == item.class.updated_at_field %>
+    <% next if attr_name.to_s == item.class.created_at_field %>
+    <div class="field">
       <label class="label"><%= attr_name %></label>
       <div class="control">
         <textarea class="textarea" placeholder="<%= attr_name %>" rows="2" id="<%= attr_name %>" name="<%= attr_name %>"><%= query_hash[attr_name] %></textarea>
       </div>
-    <% end %>
-  </div>
+    </div>
+  <% else %>
+    <% attr = attr.as(Tuple(Symbol, String) | Tuple(Symbol, String, Array(String) | String)) %>
+    <% attr_name = attr[0] %>
+    <% attr_type = attr[1] %>
+    <% next if attr_name == item.class.primary_key_field_symbol %>
+    <% next if attr_name.to_s == item.class.updated_at_field %>
+    <% next if attr_name.to_s == item.class.created_at_field %>
+    <div class="field">
+      <% if attr.is_a?(Tuple(Symbol, String)) %>
+        <% if attr_type == "bool" %>
+          <div class="control">
+            <label class="checkbox">
+              <input placeholder="<%= attr_name %>" name="<%= attr_name %>" id="<%= attr_name %>" type="checkbox" <% if query_hash[attr_name] == true %>checked="checked"<% end %>>
+              <%= attr_name %>
+            </label>
+          </div>
+        <% elsif attr_type == "int" %>
+          <label class="label"><%= attr_name %></label>
+          <div class="control">
+            <input class="input" placeholder="<%= attr_name %>" name="<%= attr_name %>" id="<%= attr_name %>" type="number" value="<%= query_hash[attr_name] %>">
+          </div>
+        <% elsif attr_type == "float" %>
+          <label class="label"><%= attr_name %></label>
+          <div class="control">
+            <input class="input" placeholder="<%= attr_name %>" name="<%= attr_name %>" id="<%= attr_name %>" type="number" step="any" value="<%= query_hash[attr_name] %>">
+          </div>
+        <% elsif attr_type == "string" %>
+          <label class="label"><%= attr_name %></label>
+          <div class="control">
+            <input class="input" placeholder="<%= attr_name %>" name="<%= attr_name %>" id="<%= attr_name %>" type="text" value="<%= query_hash[attr_name] %>">
+          </div>
+        <% elsif attr_type == "text" %>
+          <label class="label"><%= attr_name %></label>
+          <div class="control">
+            <textarea class="textarea" placeholder="<%= attr_name %>" id="<%= attr_name %>" name="<%= attr_name %>"><%= query_hash[attr_name] %></textarea>
+          </div>
+        <% elsif attr_type == "password" %>
+          <label class="label"><%= attr_name %></label>
+          <div class="control">
+            <input class="input" placeholder="<%= attr_name %>" name="<%= attr_name %>" id="<%= attr_name %>" type="password">
+          </div>
+          <p class="help is-info">Input raw password (NOT encrypted password) to set. Leave it empty if you do not want to change.</p>
+        <% elsif attr_type == "time" %>
+          <label class="label"><%= attr_name %></label>
+          <div class="control">
+            <input id="<%= attr_name %>" type="text" class="input datetime-picker" name="<%= attr_name %>" value="<%= query_hash[attr_name] %>">
+          </div>
+        <% elsif attr_type == "fixed" %>
+          <label class="label"><%= attr_name %></label>
+          <div class="control">
+            <input class="input" readonly disabled name="<%= attr_name %>" id="<%= attr_name %>" type="text" value="<%= query_hash[attr_name] %>">
+          </div>
+        <% end %>
+      <% else %>
+        <% attr = attr.as(Tuple(Symbol, String, Array(String) | String)) %>
+        <% last = attr[2] %>
+        <% if attr_type == "enum" && last.is_a?(Array(String)) %>
+          <% last = last.as(Array(String)) %>
+          <label class="label"><%= attr_name %></label>
+          <div class="control">
+            <div class="select">
+              <select id="<%= attr_name %>" name="<%= attr_name %>">
+                <% options = last %>
+                <% attr_value = query_hash[attr_name].to_s %>
+                <% options = (options.includes?(attr_value) || attr_value.empty?) ? options : (options + [attr_value]) %>
+                <% options.each do |opt| %>
+                  <% if opt == query_hash[attr_name] %>
+                    <option selected><%= opt %></option>
+                  <% else %>
+                    <option><%= opt %></option>
+                  <% end %>
+                <% end %>
+              </select>
+            </div>
+          </div>
+        <% elsif attr_type == "fixed" && last.is_a?(String) %>
+          <% last = last.as(String) %>
+          <label class="label"><%= attr_name %></label>
+          <div class="control">
+            <input class="input" readonly disabled name="<%= attr_name %>" id="<%= attr_name %>" type="text" value="<%= query_hash[attr_name] ?  query_hash[attr_name] : attr.last%>">
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+  <% end %>
 <% end %>

--- a/src/CrectoAdmin/views/admin_layout.ecr
+++ b/src/CrectoAdmin/views/admin_layout.ecr
@@ -27,7 +27,7 @@
           <div class="navbar-end">
             <% if CrectoAdmin.config.auth_enabled && CrectoAdmin.admin_signed_in?(ctx) %>
               <a class="navbar-item">
-                Signed in as <%= CrectoAdmin.current_user(ctx) %>
+                Signed in as <%= CrectoAdmin.current_user_label(ctx) %>
               </a>
               <% if CrectoAdmin.config.auth != CrectoAdmin::BasicAuth %>
                 <div class="navbar-item">
@@ -60,7 +60,7 @@
                 <% else %>
                   <li><a href="/admin/dashboard">Dashboard</a></li>
                 <% end %>
-                <% CrectoAdmin.resources.each do |resource| %>
+                <% CrectoAdmin.accessible_resources(ctx).each do |resource| %>
                   <li>
                     <% if CrectoAdmin.current_table(ctx) == resource[:model].table_name %>
                       <a class="is-active" href="/admin/<%= resource[:model].table_name %>">

--- a/src/CrectoAdmin/views/dashboard.ecr
+++ b/src/CrectoAdmin/views/dashboard.ecr
@@ -16,7 +16,7 @@
       <% CrectoAdmin.resources.each_with_index do |resource, i| %>
         <tr class="item-row" data-href="/admin/<%= resource[:model].table_name %>">
           <th><%= resource[:model].table_name.split('_').map(&.capitalize).join(' ') %></th>
-          <td><%= resource[:collection_attributes].map(&.to_s).join(", ") %></td>
+          <td><%= resource[:model_attributes].map(&.to_s).join(", ") %></td>
           <td><%= counts[i] %></td>
         </tr>
       <% end %>

--- a/src/CrectoAdmin/views/dashboard.ecr
+++ b/src/CrectoAdmin/views/dashboard.ecr
@@ -13,7 +13,7 @@
     </thead>
 
     <tbody>
-      <% CrectoAdmin.resources.each_with_index do |resource, i| %>
+      <% CrectoAdmin.accessible_resources(ctx).each_with_index do |resource, i| %>
         <tr class="item-row" data-href="/admin/<%= resource[:model].table_name %>">
           <th><%= resource[:model].table_name.split('_').map(&.capitalize).join(' ') %></th>
           <td><%= resource[:model_attributes].map(&.to_s).join(", ") %></td>

--- a/src/CrectoAdmin/views/index.ecr
+++ b/src/CrectoAdmin/views/index.ecr
@@ -34,7 +34,7 @@
       <thead>
         <tr>
           <th><%= resource[:model].primary_key_field_symbol %></th>
-          <% resource[:collection_attributes].each do |attr| %>
+          <% collection_attributes.each do |attr| %>
             <% next if attr == resource[:model].primary_key_field_symbol %>
             <th><%= attr %></th>
           <% end %>
@@ -46,7 +46,7 @@
           <% query_hash = item.to_query_hash %>
           <tr class="item-row" data-href="/admin/<%= item.class.table_name %>/<%= item.pkey_value %>">
             <td><div class="item-cell"><%= item.pkey_value %></div></td>
-            <% resource[:collection_attributes].each do |attr| %>
+            <% collection_attributes.each do |attr| %>
               <% next if attr == resource[:model].primary_key_field_symbol %>
               <td><div class="item-cell"><%= query_hash[attr] %></div></td>
             <% end %>

--- a/src/CrectoAdmin/views/show.ecr
+++ b/src/CrectoAdmin/views/show.ecr
@@ -34,7 +34,7 @@
       <pre><%= item.pkey_value %></pre>
     </div>
   </div>
-  <% resource[:show_page_attributes].each do |attr| %>
+  <% resource[:model_attributes].each do |attr| %>
     <% next if attr == resource[:model].primary_key_field_symbol %>
     <div class="field">
       <label class="label"><%= attr %></label>

--- a/src/CrectoAdmin/views/show.ecr
+++ b/src/CrectoAdmin/views/show.ecr
@@ -34,7 +34,7 @@
       <pre><%= item.pkey_value %></pre>
     </div>
   </div>
-  <% resource[:model_attributes].each do |attr| %>
+  <% model_attributes.each do |attr| %>
     <% next if attr == resource[:model].primary_key_field_symbol %>
     <div class="field">
       <label class="label"><%= attr %></label>

--- a/src/crecto-admin.cr
+++ b/src/crecto-admin.cr
@@ -17,8 +17,8 @@ module CrectoAdmin
 
   @@resources = Array(NamedTuple(model: Crecto::Model.class,
     repo: Repo.class,
+    model_attributes: Array(Symbol),
     collection_attributes: Array(Symbol),
-    show_page_attributes: Array(Symbol),
     form_attributes: Array(Tuple(Symbol, String) | Tuple(Symbol, String, Array(String))))).new
 
   def self.add_resource(resource)

--- a/src/crecto-admin.cr
+++ b/src/crecto-admin.cr
@@ -19,7 +19,7 @@ module CrectoAdmin
     repo: Repo.class,
     model_attributes: Array(Symbol),
     collection_attributes: Array(Symbol),
-    form_attributes: Array(Tuple(Symbol, String) | Tuple(Symbol, String, Array(String))))).new
+    form_attributes: Array(Symbol | Tuple(Symbol, String) | Tuple(Symbol, String, Array(String) | String)))).new
 
   def self.add_resource(resource)
     @@resources.push(resource)
@@ -46,18 +46,28 @@ module CrectoAdmin
       ctx.params.query["search"]?
   end
 
-  def self.current_user(ctx) : String
-    return "" unless CrectoAdmin.config.auth_enabled
+  def self.current_user(ctx)
+    return nil unless CrectoAdmin.config.auth_enabled
+    return nil unless CrectoAdmin.admin_signed_in?(ctx)
     if CrectoAdmin.config.auth == CrectoAdmin::BasicAuth
-      username = ctx.kemal_authorized_username?
-      return "" if username.nil?
-      return username.to_s
+      return ctx.kemal_authorized_username?
     end
-    if CrectoAdmin.config.auth == CrectoAdmin::DatabaseAuth || CrectoAdmin.config.auth == CrectoAdmin::CustomAuth
-      return "" unless ctx.session.string?(SESSION_KEY) && !ctx.session.string(SESSION_KEY).empty?
-      return ctx.session.string(SESSION_KEY)
+    if CrectoAdmin.config.auth == CrectoAdmin::DatabaseAuth
+      user_id = ctx.session.string?(SESSION_KEY).to_s
+      return Repo.get!(CrectoAdmin.config.auth_model.not_nil!, user_id)
     end
-    return ""
+    if CrectoAdmin.config.auth == CrectoAdmin::CustomAuth
+      return ctx.session.string?(SESSION_KEY)
+    end
+    return nil
+  end
+
+  def self.current_user_label(ctx)
+    user = CrectoAdmin.current_user(ctx)
+    if user.is_a?(Crecto::Model)
+      return user.to_query_hash[CrectoAdmin.config.auth_model_identifier.not_nil!].to_s
+    end
+    return user.to_s
   end
 
   def self.current_table(ctx)
@@ -81,6 +91,35 @@ module CrectoAdmin
       end
     end
   end
+
+  def self.model_accessibility(ctx, resource)
+    user = CrectoAdmin.current_user(ctx)
+    model = resource[:model]
+    attributes = [] of Symbol
+    query = Crecto::Repo::Query.new
+    return {query, resource[:model_attributes]} unless model.responds_to?(:can_access)
+    result = model.can_access(user)
+    if result.is_a?(Bool)
+      return {query, resource[:model_attributes]} if result.as(Bool)
+      return {nil, attributes}
+    elsif result.is_a?(Crecto::Repo::Query)
+      return {result.as(Crecto::Repo::Query), resource[:model_attributes]}
+    elsif result.is_a?(Array(Symbol))
+      return {query, result.as(Array(Symbol))}
+    elsif result.is_a?(Tuple(Crecto::Repo::Query, Array(Symbol)))
+      return result.as(Tuple(Crecto::Repo::Query, Array(Symbol)))
+    end
+    return {query, resource[:model_attributes]}
+  end
+
+  def self.accessible_resources(ctx)
+    @@resources.select do |resource|
+      accessibility = CrectoAdmin.model_accessibility(ctx, resource)
+      query = accessibility[0]
+      attributes = accessibility[1]
+      !query.nil? && !attributes.empty?
+    end
+  end
 end
 
 def self.init_admin
@@ -102,7 +141,11 @@ def self.init_admin
   get "/admin/dashboard" do |ctx|
     counts = [] of Int64
     CrectoAdmin.resources.each do |resource|
-      counts << resource[:repo].aggregate(resource[:model], :count, resource[:model].primary_key_field_symbol).as(Int64)
+      accessibility = CrectoAdmin.model_accessibility(ctx, resource)
+      next if accessibility[0].nil?
+      next if accessibility[1].empty?
+      query = accessibility[0].as(Crecto::Repo::Query)
+      counts << resource[:repo].aggregate(resource[:model], :count, resource[:model].primary_key_field_symbol, query).as(Int64)
     end
     ecr "dashboard"
   end
@@ -136,7 +179,7 @@ def self.init_admin
         user = users.first
         encrypted_password = user.to_query_hash[CrectoAdmin.config.auth_model_password.not_nil!].to_s
         if Crypto::Bcrypt::Password.new(encrypted_password) == password
-          authorized = user_identifier
+          authorized = user.pkey_value.to_s
         end
       end
     end

--- a/src/crecto-admin.cr
+++ b/src/crecto-admin.cr
@@ -96,6 +96,7 @@ module CrectoAdmin
     user = CrectoAdmin.current_user(ctx)
     attributes = [] of Symbol
     query = Crecto::Repo::Query.new
+    return {query, resource[:model_attributes]} unless CrectoAdmin.config.auth_enabled
     if resource[:model].responds_to? :can_access
       result = resource[:model].can_access(user)
       if result.is_a?(Bool)


### PR DESCRIPTION
Sorry this PR is messing, because I made a lot of change in one commit without seperate commits. I will avoid this happen in the future.
- added `fixed` type into `form_attributes` and make the form_attribute type more generic. The `fixed` type makes a readonly input with the original value or default value if provided. Make the `form_attributes : Array(Symbol | Tuple(Symbol, String) | Tuple(Symbol, String, Array(String) | String))` so that user could declare it more freely.
- made the `CrectoAdmin.current_user` return `Nil | String | Crecto::Model(only when DatabaseAuth)` so that the output could be used as the input to the permission method user defined.
- add a `model_attributes` in resource to make the permisson check easily
- Implemented access permission based on `Crecto::Model` class method: `can_access`. User could declare the `self.can_access` method specify that who can access what records of what fields.
  `def self.can_access(user : Nil | String | Crecto::Model) : Bool | Array(Symbol) | Crecto::Repo::Query | Tuple(Crecto::Repo::Query, Array(Symbol))`
The input of this method is the output of `current_user` method, the output:
      `true`: all records and all fields
      `false`: none
      `Array(Symbol)`: all records of the specific fields
      `Crecto::Repo::Query`: the records returned by the specific query
      `Tuple(Crecto::Repo::Query, Array(Symbol))`: the records of the specific query of the specific fields
- the dashboard, index, search page will use the access permission to make the query and return the results.
