### PR TITLE
Hengle/other permission

### DIFF
--- a/spec/test_pg.cr
+++ b/spec/test_pg.cr
@@ -28,6 +28,11 @@ class User < Crecto::Model
     return [{:email, "fixed"}, :encrypted_password]
   end
 
+  def can_delete(user)
+    return false unless user.is_a? User
+    user.email.to_s == "jianghengle@gmail.com"
+  end
+
   def self.collection_attributes
     [:email, :status, :count, :score, :is_active, :first_posted, :last_posted, :updated_at, :created_at]
   end
@@ -49,6 +54,12 @@ class User < Crecto::Model
     query = Crecto::Repo::Query.where(id: user.id)
     return {query, [:email, :encrypted_password, :status]}
   end
+
+  def self.can_create(user)
+    return false unless user.is_a? User
+    return true if user.email.to_s == "jianghengle@gmail.com"
+    false
+  end
 end
 
 class Post < Crecto::Model
@@ -60,7 +71,8 @@ class Post < Crecto::Model
   def can_edit(user)
     return false unless user.is_a? User
     return true if user.email.to_s == "jianghengle@gmail.com"
-    return [:content]
+    return [:content] if @user_id.to_s == user.id.to_s
+    false
   end
 
   def self.search_attributes
@@ -72,10 +84,10 @@ class Post < Crecto::Model
      {:content, "text"}]
   end
 
-  def self.can_access(user)
+  def self.can_create(user)
     return false unless user.is_a? User
     return true if user.email.to_s == "jianghengle@gmail.com"
-    Crecto::Repo::Query.where(user_id: user.id)
+    [{:user_id, "fixed", user.id.to_s}, :content]
   end
 end
 

--- a/spec/test_pg.cr
+++ b/spec/test_pg.cr
@@ -22,6 +22,12 @@ class User < Crecto::Model
     field :last_posted, Time
   end
 
+  def can_edit(user)
+    return false unless user.is_a? User
+    return true if user.email.to_s == "jianghengle@gmail.com"
+    return [{:email, "fixed"}, :encrypted_password]
+  end
+
   def self.collection_attributes
     [:email, :status, :count, :score, :is_active, :first_posted, :last_posted, :updated_at, :created_at]
   end
@@ -39,7 +45,6 @@ class User < Crecto::Model
 
   def self.can_access(user)
     return false unless user.is_a? User
-    user = user.as(User)
     return true if user.email.to_s == "jianghengle@gmail.com"
     query = Crecto::Repo::Query.where(id: user.id)
     return {query, [:email, :encrypted_password, :status]}
@@ -50,6 +55,12 @@ class Post < Crecto::Model
   schema "posts" do
     field :user_id, Int64
     field :content, String
+  end
+
+  def can_edit(user)
+    return false unless user.is_a? User
+    return true if user.email.to_s == "jianghengle@gmail.com"
+    return [:content]
   end
 
   def self.search_attributes
@@ -63,7 +74,6 @@ class Post < Crecto::Model
 
   def self.can_access(user)
     return false unless user.is_a? User
-    user = user.as(User)
     return true if user.email.to_s == "jianghengle@gmail.com"
     Crecto::Repo::Query.where(user_id: user.id)
   end

--- a/src/CrectoAdmin/resource.cr
+++ b/src/CrectoAdmin/resource.cr
@@ -43,7 +43,8 @@ def self.admin_resource(model : Crecto::Model.class, repo, **opts)
 
   # Index
   get "/admin/#{model.table_name}" do |ctx|
-    access = CrectoAdmin.model_access(ctx, resource)
+    user = CrectoAdmin.current_user(ctx)
+    access = CrectoAdmin.check_access(user, resource)
     next if access[0].nil? || access[1].empty?
     model_query = access[0].as(Crecto::Repo::Query)
     collection_attributes = resource[:collection_attributes].select { |a| access[1].includes? a }
@@ -51,12 +52,14 @@ def self.admin_resource(model : Crecto::Model.class, repo, **opts)
     query = model_query.limit(per_page).offset(offset)
     data = repo.all(model, query)
     count = repo.aggregate(model, :count, resource[:model].primary_key_field_symbol, model_query).as(Int64)
+    form_attributes = CrectoAdmin.check_create(user, resource, access[1])
     ecr("index")
   end
 
   # Search
   get "/admin/#{model.table_name}/search" do |ctx|
-    access = CrectoAdmin.model_access(ctx, resource)
+    user = CrectoAdmin.current_user(ctx)
+    access = CrectoAdmin.check_access(user, resource)
     next if access[0].nil? || access[1].empty?
     model_query = access[0].as(Crecto::Repo::Query)
     collection_attributes = resource[:collection_attributes].select { |a| access[1].includes? a }
@@ -64,29 +67,32 @@ def self.admin_resource(model : Crecto::Model.class, repo, **opts)
     search_attributes.delete(model.primary_key_field_symbol)
     search_attributes.unshift(model.primary_key_field_symbol)
     offset = ctx.params.query["offset"]? ? ctx.params.query["offset"].to_i : 0
-    search_string = search_attributes.map { |sa| "#{CrectoAdmin.field_cast(sa, repo)} LIKE ?" }.join(" OR ")
+    search_string = "(" + search_attributes.map { |sa| "#{CrectoAdmin.field_cast(sa, repo)} LIKE ?" }.join(" OR ") + ")"
     search_params = (1..search_attributes.size).map { |x| "%#{CrectoAdmin.search_param(ctx)}%" }
     query = model_query
       .limit(per_page)
       .where(search_string, search_params)
       .offset(offset)
     data = repo.all(model, query)
-    count = repo.aggregate(model, :count, resource[:model].primary_key_field_symbol, model_query).as(Int64)
+    count = repo.aggregate(model, :count, resource[:model].primary_key_field_symbol, model_query.where(search_string, search_params)).as(Int64)
+    form_attributes = CrectoAdmin.check_create(user, resource, access[1])
     ecr("index")
   end
 
   # New form
   get "/admin/#{model.table_name}/new" do |ctx|
-    access = CrectoAdmin.model_access(ctx, resource)
+    user = CrectoAdmin.current_user(ctx)
+    access = CrectoAdmin.check_access(user, resource)
     next if access[0].nil? || access[1].empty?
     item = model.new
-    form_attributes = CrectoAdmin.model_create(ctx, resource, access[1])
+    form_attributes = CrectoAdmin.check_create(user, resource, access[1])
     ecr("new")
   end
 
   # View
   get "/admin/#{model.table_name}/:id" do |ctx|
-    access = CrectoAdmin.model_access(ctx, resource)
+    user = CrectoAdmin.current_user(ctx)
+    access = CrectoAdmin.check_access(user, resource)
     next if access[0].nil? || access[1].empty?
     model_query = access[0].as(Crecto::Repo::Query)
     query = model_query.where(resource[:model].primary_key_field_symbol, ctx.params.url["id"])
@@ -94,16 +100,18 @@ def self.admin_resource(model : Crecto::Model.class, repo, **opts)
     next if data.empty?
     item = data.first
     model_attributes = access[1]
-    form_attributes = CrectoAdmin.item_edit(ctx, resource, item, access[1])
+    form_attributes = CrectoAdmin.check_edit(user, resource, item, access[1])
+    can_delete = CrectoAdmin.check_delete(user, resource, item, form_attributes)
     ecr("show")
   end
 
   # Update
   put "/admin/#{model.table_name}/:pid_id" do |ctx|
-    access = CrectoAdmin.model_access(ctx, resource)
+    user = CrectoAdmin.current_user(ctx)
+    access = CrectoAdmin.check_access(user, resource)
     next if access[0].nil? || access[1].empty?
     item = repo.get!(model, ctx.params.url["pid_id"])
-    form_attributes = CrectoAdmin.item_edit(ctx, resource, item, access[1])
+    form_attributes = CrectoAdmin.check_edit(user, resource, item, access[1])
     query_hash = ctx.params.body.to_h
     form_attributes.each do |attr|
       next if attr.is_a? Symbol
@@ -134,14 +142,15 @@ def self.admin_resource(model : Crecto::Model.class, repo, **opts)
 
   # Edit form
   get "/admin/#{model.table_name}/:id/edit" do |ctx|
-    access = CrectoAdmin.model_access(ctx, resource)
+    user = CrectoAdmin.current_user(ctx)
+    access = CrectoAdmin.check_access(user, resource)
     next if access[0].nil? || access[1].empty?
     model_query = access[0].as(Crecto::Repo::Query)
     query = model_query.where(resource[:model].primary_key_field_symbol, ctx.params.url["id"])
     data = repo.all(model, query).not_nil!
     next if data.empty?
     item = data.first
-    form_attributes = CrectoAdmin.item_edit(ctx, resource, item, access[1])
+    form_attributes = CrectoAdmin.check_edit(user, resource, item, access[1])
     ecr("edit")
   end
 
@@ -178,7 +187,13 @@ def self.admin_resource(model : Crecto::Model.class, repo, **opts)
 
   # Delete
   get "/admin/#{model.table_name}/:id/delete" do |ctx|
+    user = CrectoAdmin.current_user(ctx)
+    access = CrectoAdmin.check_access(user, resource)
+    next if access[0].nil? || access[1].empty?
     item = repo.get!(model, ctx.params.url["id"])
+    form_attributes = CrectoAdmin.check_edit(user, resource, item, access[1])
+    can_delete = CrectoAdmin.check_delete(user, resource, item, form_attributes)
+    next unless can_delete
     changeset = repo.delete(item)
 
     if changeset.errors.any?

--- a/src/CrectoAdmin/views/_form_fields.ecr
+++ b/src/CrectoAdmin/views/_form_fields.ecr
@@ -1,4 +1,4 @@
-<% resource[:form_attributes].each do |attr| %>
+<% form_attributes.each do |attr| %>
   <% query_hash = item.to_query_hash %>
   <% if attr.is_a? Symbol %>
     <% attr_name = attr.as(Symbol) %>

--- a/src/CrectoAdmin/views/index.ecr
+++ b/src/CrectoAdmin/views/index.ecr
@@ -7,12 +7,14 @@
     <span class="is-size-6" style="line-height:2.3;">
       Total rows: <%= count %>
     </span>&nbsp;&nbsp;
-    <a class="button" href="/admin/<%= resource[:model].table_name %>/new">
-      <span class="icon">
-        <i class="fas fa-plus"></i>
-      </span>
-      <span>New</span>
-    </a>
+    <% unless form_attributes.empty? %>
+      <a class="button" href="/admin/<%= resource[:model].table_name %>/new">
+        <span class="icon">
+          <i class="fas fa-plus"></i>
+        </span>
+        <span>New</span>
+      </a>
+    <% end %>
   </div>
   <div class="column">
     <form method="GET" action="/admin/<%= resource[:model].table_name %>/search">

--- a/src/CrectoAdmin/views/show.ecr
+++ b/src/CrectoAdmin/views/show.ecr
@@ -11,19 +11,23 @@
 </div>
 
 <div class="field is-grouped">
-  <p class="control">
-    <a class="button is-info" href="/admin/<%= item.class.table_name %>/<%= item.pkey_value %>/edit">
-      <span class="icon"><i class="fas fa-edit"></i></span>
-      <span>Edit</span>
-    </a>
-  </p>
-  <p class="control">
-    <a class="button is-danger" href="/admin/<%= item.class.table_name %>/<%= item.pkey_value %>/delete"
-      onclick="return confirm('Are you sure to delete this record from the database?')">
-      <span class="icon"><i class="fas fa-trash"></i></span>
-      <span>Delete</span>
-    </a>
-  </p>
+  <% unless form_attributes.empty? %>
+    <p class="control">
+      <a class="button is-info" href="/admin/<%= item.class.table_name %>/<%= item.pkey_value %>/edit">
+        <span class="icon"><i class="fas fa-edit"></i></span>
+        <span>Edit</span>
+      </a>
+    </p>
+  <% end %>
+  <% if can_delete %>
+    <p class="control">
+      <a class="button is-danger" href="/admin/<%= item.class.table_name %>/<%= item.pkey_value %>/delete"
+        onclick="return confirm('Are you sure to delete this record from the database?')">
+        <span class="icon"><i class="fas fa-trash"></i></span>
+        <span>Delete</span>
+      </a>
+    </p>
+  <% end %>
 </div>
 
 <div>


### PR DESCRIPTION
Finished all permissions:
- Access (view): class method on Model  `self.can_access(user) : Bool | Array(Symbol) | Query | Tuple(Query, Array(Symbol))` as implemented in the previous commit
- Create: class method on Model `self.can_create(user) : Bool | Array(Symbol | Tuple(Symbol, String) | Tuple(Symbol, String, Array(String) | String))`:
    `false` cannot create
    `true` can create with all form_attributes
    `Array(Symbol | Tuple(Symbol, String) | Tuple(Symbol, String, Array(String) | String))`: can create with these form attributes merged with the global form attributes and accessible attributes
- Edit: instance method on Model `can_edit(user) : Bool | Array(Symbol | Tuple(Symbol, String) | Tuple(Symbol, String, Array(String) | String))` same as `Create` but instead on instance
- Delete: instance method on Model `can_delete(user) : Bool`
    `true` can delete
    `false` can not delete
    not defined can delete only if can edit

Run into a compiled error that even with responds_to? class method on Model, it still said on such the method on the Model class. So I declare the two class methods `Crecto::Model.can_access(user)` and `Crecto::Model.can_create(user)` in advance and could be overridden by users.