### PR TITLE
Hengle/auto resources

### DIFF
--- a/examples/auto.cr
+++ b/examples/auto.cr
@@ -9,7 +9,7 @@ module Repo
   extend Crecto::Repo
   config do |conf|
     conf.adapter = Crecto::Adapters::Mysql
-    conf.uri = "mysql://root:root@localhost:3306/unlcms2" # use your database uri
+    conf.uri = "mysql://root:root@localhost:3306/crecto_test" # use your database uri
   end
 end
 

--- a/examples/auto.cr
+++ b/examples/auto.cr
@@ -1,0 +1,17 @@
+# This will generate the crecto admin code for all tables in the database
+# Only works for Mysql database currently
+# Redirect the output code to the src folder and run/debug it manually
+require "mysql"
+require "../src/crecto-admin" # require "crecto-admin" instead if installed crecto-admin
+
+# Setup your repo
+module Repo
+  extend Crecto::Repo
+  config do |conf|
+    conf.adapter = Crecto::Adapters::Mysql
+    conf.uri = "mysql://root:root@localhost:3306/unlcms2" # use your database uri
+  end
+end
+
+# Generate Crystal code
+auto_script(Repo)

--- a/src/CrectoAdmin/auto_resource.cr
+++ b/src/CrectoAdmin/auto_resource.cr
@@ -1,0 +1,176 @@
+module CrectoAdmin
+  class Column
+    property column_name : String
+    property column_key : String
+    property extra : String
+    property data_type : String
+
+    def initialize(@column_name, @column_key, @extra, @data_type)
+    end
+
+    def is_created_at?
+      column_name = @column_name.downcase
+      data_type = @data_type.downcase
+      (column_name == "created_at") && (data_type == "datetime")
+    end
+
+    def is_updated_at?
+      column_name = @column_name.downcase
+      data_type = @data_type.downcase
+      (column_name == "updated_at") && (data_type == "datetime")
+    end
+
+    def column_type
+      t = @data_type.upcase
+      return "Bool" if t.includes? "BOOL"
+      return "Int64" if t.includes?("INT") || t.includes?("SERIAL")
+      return "Float64" if t.includes?("DEC") || t.includes?("FLOAT") || t.includes?("DOUBLE")
+      return "Time" if t.includes? "DATETIME"
+      return "String" if t.includes?("CHAR") || t.includes?("TEXT")
+      nil
+    end
+  end
+
+  class Table
+    property db_name : String
+    property table_name : String
+    property columns : Array(CrectoAdmin::Column)
+    property class_name : String
+
+    def initialize(@db_name, @table_name)
+      @columns = [] of CrectoAdmin::Column
+      @class_name = "#{table_name[0].upcase}#{table_name[1..-1]}"
+    end
+
+    def has_created_at?
+      @columns.each do |column|
+        return true if column.is_created_at?
+      end
+      false
+    end
+
+    def has_updated_at?
+      @columns.each do |column|
+        return true if column.is_updated_at?
+      end
+      false
+    end
+
+    def primary_key_column
+      pri_columns = [] of CrectoAdmin::Column
+      @columns.each do |column|
+        column_key = column.column_key.downcase
+        pri_columns << column if column_key.includes?("pri")
+      end
+      return nil if pri_columns.empty?
+      pri_columns.each do |column|
+        return column if column.column_name.includes? "id"
+      end
+      pri_columns[0]
+    end
+
+    def has_primary_key_auto?
+      pri_column = primary_key_column
+      return false if pri_column.nil?
+      pri_column = pri_column.as(CrectoAdmin::Column)
+      pri_column.extra.includes?("auto_increment")
+    end
+  end
+
+  def self.build_header(uri)
+    String.build do |s|
+      s << "require \"mysql\"\n"
+      s << "require \"crecto-admin\"\n\n"
+      s << "module Repo\n"
+      s << "  extend Crecto::Repo\n"
+      s << "  config do |conf|\n"
+      s << "    conf.adapter = Crecto::Adapters::Mysql\n"
+      s << "    conf.uri = \"" << uri << "\"\n"
+      s << "  end\n"
+      s << "end\n\n"
+      s << "init_admin()\n\n"
+    end
+  end
+
+  def self.build_class(table)
+    return "# skip table: #{table.table_name}, no primary_key\n\n" if table.primary_key_column.nil?
+    return "# skip table: #{table.table_name}, only primary_key\n\n" if table.columns.size < 2
+    String.build do |s|
+      s << "class #{table.class_name} < Crecto::Model\n"
+      s << "  set_created_at_field nil\n" unless table.has_created_at?
+      s << "  set_updated_at_field nil\n" unless table.has_updated_at?
+      s << "  schema \"#{table.table_name}\" do\n"
+      columns_symbols = [] of String
+      table.columns.each do |column|
+        if column == table.primary_key_column
+          s << "    field :#{column.column_name}, PkeyValue, primary_key: true\n"
+          columns_symbols << ":#{column.column_name}"
+        elsif column.is_created_at? || column.is_updated_at?
+          next
+        elsif column.column_type.nil?
+          s << "    # skip column: #{column.column_name} (#{column.data_type})\n"
+        else
+          s << "    field :#{column.column_name}, #{column.column_type}\n"
+          columns_symbols << ":#{column.column_name}"
+        end
+      end
+      s << "  end\n"
+      unless table.has_primary_key_auto?
+        s << "  def self.form_attributes\n"
+        s << "    [#{columns_symbols.join(", ")}]\n"
+        s << "  end\n"
+      end
+      s << "end\n"
+      s << "admin_resource(#{table.class_name}, Repo)\n\n"
+    end
+  end
+
+  def self.build_tail
+    String.build do |s|
+      s << "Kemal::Session.config do |config|\n"
+      s << "  config.secret = \"my super secret\"\n"
+      s << "end\n"
+      s << "Kemal.run\n\n"
+    end
+  end
+end
+
+def self.auto_script(repo)
+  db_uri = repo.config.database_url
+  index1 = db_uri.rindex('/')
+  index1 = -1 if index1.nil?
+  info_uri = db_uri[0..index1] + "information_schema"
+  index2 = db_uri.index('?')
+  index2 = -1 if index2.nil?
+  db_name = db_uri[index1 + 1..index2]
+  db_uri = db_uri[0..(index2 - 1)] unless index2 == -1
+
+  tables = {} of String => CrectoAdmin::Table
+  DB.open info_uri do |db|
+    db.query "select table_name, column_name, column_key, extra, data_type from columns where table_schema = '#{db_name}'" do |rs|
+      rs.each do
+        table_name = rs.read(String)
+        column_name = rs.read(String)
+        column_key = rs.read(String)
+        extra = rs.read(String)
+        data_type = rs.read(String)
+        tables[table_name] = CrectoAdmin::Table.new(db_name, table_name) unless tables.has_key? table_name
+        tables[table_name].columns << CrectoAdmin::Column.new(column_name, column_key, extra, data_type)
+      end
+    end
+  end
+
+  header = CrectoAdmin.build_header(db_uri)
+  classes = tables.values.map do |table|
+    CrectoAdmin.build_class(table)
+  end
+  tail = CrectoAdmin.build_tail
+  all = String.build do |s|
+    s << header
+    classes.each do |c|
+      s << c
+    end
+    s << tail
+  end
+  puts all
+end

--- a/src/CrectoAdmin/resource.cr
+++ b/src/CrectoAdmin/resource.cr
@@ -29,8 +29,8 @@ def self.admin_resource(model : Crecto::Model.class, repo, **opts)
     form_attributes = CrectoAdmin.merge_form_attributes(model.form_attributes, form_attributes)
   else
     form_attributes = form_attributes.select do |a|
-      next a == model.primary_key_field_symbol if a.is_a? Symbol
-      a[0] == model.primary_key_field_symbol
+      next a != model.primary_key_field_symbol if a.is_a? Symbol
+      a[0] != model.primary_key_field_symbol
     end
   end
 

--- a/src/CrectoAdmin/resource.cr
+++ b/src/CrectoAdmin/resource.cr
@@ -70,7 +70,8 @@ def self.admin_resource(model : Crecto::Model.class, repo, **opts)
       per_page = count.to_s.to_i
     end
     per_page = CrectoAdmin.config.items_per_page unless per_page > 0
-    query = query.limit(per_page).offset(offset).order_by(order_by)
+    selection = collection_attributes.map(&.to_s)
+    query = query.select(selection).limit(per_page).offset(offset).order_by(order_by)
     data = repo.all(model, query)
     form_attributes = CrectoAdmin.check_create(user, resource, access[1])
     search_param = nil
@@ -108,7 +109,8 @@ def self.admin_resource(model : Crecto::Model.class, repo, **opts)
       per_page = count.to_s.to_i
     end
     per_page = CrectoAdmin.config.items_per_page unless per_page > 0
-    query = query.limit(per_page).offset(offset).order_by(order_by)
+    selection = collection_attributes.map(&.to_s)
+    query = query.select(selection).limit(per_page).offset(offset).order_by(order_by)
     data = repo.all(model, query)
     form_attributes = CrectoAdmin.check_create(user, resource, access[1])
     ecr("index")
@@ -131,12 +133,13 @@ def self.admin_resource(model : Crecto::Model.class, repo, **opts)
     accesses = CrectoAdmin.check_resources(user)
     access = accesses[resource_index]
     next if access[0].nil? || access[1].empty?
+    model_attributes = access[1]
     query = access[0].as(Crecto::Repo::Query)
-    query = query.where(resource[:model].primary_key_field_symbol, ctx.params.url["id"])
+    selection = model_attributes.map(&.to_s)
+    query = query.select(selection).where(resource[:model].primary_key_field_symbol, ctx.params.url["id"])
     data = repo.all(model, query).not_nil!
     next if data.empty?
     item = data.first
-    model_attributes = access[1]
     form_attributes = CrectoAdmin.check_edit(user, resource, item, access[1])
     can_delete = CrectoAdmin.check_delete(user, resource, item, form_attributes)
     ecr("show")
@@ -148,7 +151,13 @@ def self.admin_resource(model : Crecto::Model.class, repo, **opts)
     accesses = CrectoAdmin.check_resources(user)
     access = accesses[resource_index]
     next if access[0].nil? || access[1].empty?
-    item = repo.get!(model, ctx.params.url["pid_id"])
+    query = access[0].as(Crecto::Repo::Query)
+    model_attributes = access[1]
+    selection = model_attributes.map(&.to_s)
+    query = query.select(selection).where(resource[:model].primary_key_field_symbol, ctx.params.url["pid_id"])
+    data = repo.all(model, query).not_nil!
+    next if data.empty?
+    item = data.first
     form_attributes = CrectoAdmin.check_edit(user, resource, item, access[1])
     query_hash = ctx.params.body.to_h
     form_attributes.each do |attr|
@@ -187,7 +196,9 @@ def self.admin_resource(model : Crecto::Model.class, repo, **opts)
     access = accesses[resource_index]
     next if access[0].nil? || access[1].empty?
     query = access[0].as(Crecto::Repo::Query)
-    query = query.where(resource[:model].primary_key_field_symbol, ctx.params.url["id"])
+    model_attributes = access[1]
+    selection = model_attributes.map(&.to_s)
+    query = query.select(selection).where(resource[:model].primary_key_field_symbol, ctx.params.url["id"])
     data = repo.all(model, query).not_nil!
     next if data.empty?
     item = data.first
@@ -243,7 +254,13 @@ def self.admin_resource(model : Crecto::Model.class, repo, **opts)
     accesses = CrectoAdmin.check_resources(user)
     access = accesses[resource_index]
     next if access[0].nil? || access[1].empty?
-    item = repo.get!(model, ctx.params.url["id"])
+    query = access[0].as(Crecto::Repo::Query)
+    model_attributes = access[1]
+    selection = model_attributes.map(&.to_s)
+    query = query.select(selection).where(resource[:model].primary_key_field_symbol, ctx.params.url["id"])
+    data = repo.all(model, query).not_nil!
+    next if data.empty?
+    item = data.first
     form_attributes = CrectoAdmin.check_edit(user, resource, item, access[1])
     can_delete = CrectoAdmin.check_delete(user, resource, item, form_attributes)
     next unless can_delete

--- a/src/CrectoAdmin/views/_form_fields.ecr
+++ b/src/CrectoAdmin/views/_form_fields.ecr
@@ -1,8 +1,8 @@
 <% form_attributes.each do |attr| %>
   <% query_hash = item.to_query_hash %>
+  <% query_hash[item.class.primary_key_field_symbol] = item.pkey_value %>
   <% if attr.is_a? Symbol %>
     <% attr_name = attr.as(Symbol) %>
-    <% next if attr_name == item.class.primary_key_field_symbol %>
     <% next if attr_name.to_s == item.class.updated_at_field %>
     <% next if attr_name.to_s == item.class.created_at_field %>
     <div class="field">
@@ -15,7 +15,6 @@
     <% attr = attr.as(Tuple(Symbol, String) | Tuple(Symbol, String, Array(String) | String)) %>
     <% attr_name = attr[0] %>
     <% attr_type = attr[1] %>
-    <% next if attr_name == item.class.primary_key_field_symbol %>
     <% next if attr_name.to_s == item.class.updated_at_field %>
     <% next if attr_name.to_s == item.class.created_at_field %>
     <div class="field">

--- a/src/CrectoAdmin/views/dashboard.ecr
+++ b/src/CrectoAdmin/views/dashboard.ecr
@@ -6,6 +6,7 @@
   <table class="table is-fullwidth is-hoverable is-striped">
     <thead>
       <tr>
+        <th>Index</th>
         <th>Model</th>
         <th>Attributes</th>
         <th>Records</th>
@@ -18,6 +19,7 @@
         <% next if access[0].nil? %>
         <% next if access[1].empty? %>
         <tr class="item-row" data-href="/admin/<%= resource[:index] %>">
+          <th><%= resource[:index] %></th>
           <th><%= resource[:model].table_name.split('_').map(&.capitalize).join(' ') %></th>
           <td><%= resource[:model_attributes].map(&.to_s).join(", ") %></td>
           <td><%= counts[resource[:index]] %></td>

--- a/src/crecto-admin.cr
+++ b/src/crecto-admin.cr
@@ -144,11 +144,17 @@ module CrectoAdmin
       if result.is_a? Bool
         return empty unless result
       else
-        form_base = CrectoAdmin.filter_form_attributes(result, accessible)
+        form_base = CrectoAdmin.filter_form_attributes(result, accessible).select do |a|
+          next a != item.class.primary_key_field_symbol if a.is_a? Symbol
+          a[0] != item.class.primary_key_field_symbol
+        end
         return CrectoAdmin.merge_form_attributes(form_base, resource[:form_attributes])
       end
     end
-    CrectoAdmin.filter_form_attributes(resource[:form_attributes], accessible)
+    CrectoAdmin.filter_form_attributes(resource[:form_attributes], accessible).select do |a|
+      next a != item.class.primary_key_field_symbol if a.is_a? Symbol
+      a[0] != item.class.primary_key_field_symbol
+    end
   end
 
   def self.filter_form_attributes(form_attributes, attributes)


### PR DESCRIPTION
Some system admins in our center are interested in using crecto admin as a UI for them the manipulate the database. But they want to be able generate the code automatically given a database or repo. So I made a function reading the Mysql information_schema database to get all tables and columns and then generate the admin code automatically.
- Auto resource function
- Some primary field has no auto_increment function. When create the record, allow the user to set this primary field if he specify the primary field in the form attributes method
- Only select attributes defined in the model from the database. Because I run into a problem that the database adapter cannot retrieve some fields with weird types, even I did not define it in the model. So I only select defined fields to work around the bug.
- Added resource index in the dashboard page. 