### PR TITLE
Upgrade to Crystal 0.26.1

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -4,7 +4,7 @@ version: 0.2.0
 authors:
   - Nick Franken <shnick@gmail.com>
 
-crystal: 0.25.1
+crystal: 0.26.1
 
 license: MIT
 
@@ -14,27 +14,22 @@ dependencies:
 
   crecto:
     github: crecto/crecto
-    version: 0.9.0
+    branch: master
 
   kemal:
     github: kemalcr/kemal
-    version: 0.23.0
 
   kemal-csrf:
     github: kemalcr/kemal-csrf
-    version: 0.5.0
 
   kemal-session:
     github: kemalcr/kemal-session
-    version: 0.10.0
 
   kemal-flash:
     github: neovintage/kemal-flash
-    version: 0.1.0
 
   kemal-basic-auth:
     github: kemalcr/kemal-basic-auth
-    version: 0.2.0
 
 development_dependencies:
   mysql:

--- a/src/CrectoAdmin/init_admin.cr
+++ b/src/CrectoAdmin/init_admin.cr
@@ -189,7 +189,7 @@ def self.init_admin
   end
 
   # Update
-  put "/admin/resources/:resource_index/:pid_id" do |ctx|
+  post "/admin/resources/:resource_index/:pid_id" do |ctx|
     resource_index = ctx.params.url["resource_index"].to_i
     resource = CrectoAdmin.resources[resource_index]
     model = resource[:model]


### PR DESCRIPTION
Upgrade to Crystal 0.26.1
Use Crecto `master` branch for the compile improvement and the `Time.parse!` in 0.26.1
Just found using `put` in update does not work so use `post`

@fridgerator can I made a release 0.2.0 in `Crecto/crecto-admin` after merging this?
